### PR TITLE
pass preview props down to pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-wordsby",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "A Gatsby plugin for Wordsby/Wordpress",
   "main": "index.js",
   "scripts": {

--- a/src/components/PageElement.js
+++ b/src/components/PageElement.js
@@ -1,10 +1,10 @@
 import React from "react";
 import Yoast from "./Yoast";
 
-const PageElement = ({ children, pageContext }) => (
+const PageElement = ({ children, pageContext, data }) => (
   <>
     <Yoast {...pageContext} />
-    {children}
+    {React.cloneElement(children, { data })}
   </>
 );
 

--- a/src/components/Preview/index.js
+++ b/src/components/Preview/index.js
@@ -137,12 +137,10 @@ class Preview extends Component {
       const childrenWithPreview = React.Children.map(children, child => {
         return React.cloneElement(child, {
           data: {
-            wordpressWpCollections: this.state.previewData,
             wordsbyCollections: this.state.previewData,
             ...rest
           },
           previewData: {
-            wordpressWpCollections: this.state.previewData,
             wordsbyCollections: this.state.previewData,
             ...rest
           }

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -7,7 +7,7 @@ exports.wrapPageElement = ({ element, props }, pluginOptions) => {
   if (props.pageContext && props.pageContext.preview) {
     return (
       <Preview {...props}>
-        <PageElement {...props}>{element}</PageElement>
+        <PageElement>{element}</PageElement>
       </Preview>
     );
   } else if (
@@ -25,7 +25,7 @@ exports.wrapPageElement = ({ element, props }, pluginOptions) => {
         }
         {...props}
       >
-        <PageElement {...props}>{element}</PageElement>
+        <PageElement>{element}</PageElement>
       </InstantPublish>
     );
   } else {


### PR DESCRIPTION
when the PageElement component was added it broke previews because it spread the original props back onto the Preview components children. THis fixes that.